### PR TITLE
Make ClassName compareTo consistent with equals

### DIFF
--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/AnnotationSpec.kt
@@ -40,6 +40,13 @@ public class AnnotationSpec private constructor(
   public val members: List<CodeBlock> = builder.members.toImmutableList()
   public val useSiteTarget: UseSiteTarget? = builder.useSiteTarget
 
+  /** Lazily-initialized toString of this type name.  */
+  private val cachedString by lazy {
+    buildCodeString {
+      emit(this, inline = true, asParameter = false)
+    }
+  }
+
   internal fun emit(codeWriter: CodeWriter, inline: Boolean, asParameter: Boolean = false) {
     if (!asParameter) {
       codeWriter.emit("@")
@@ -96,9 +103,7 @@ public class AnnotationSpec private constructor(
 
   override fun hashCode(): Int = toString().hashCode()
 
-  override fun toString(): String = buildCodeString {
-    emit(this, inline = true, asParameter = false)
-  }
+  override fun toString(): String = cachedString
 
   public enum class UseSiteTarget(internal val keyword: String) {
     FILE("file"),

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
@@ -78,7 +78,7 @@ public class ClassName internal constructor(
   private val comparableNames = names.joinToString()
 
   /** String representation of the annotations used when comparing to other ClassName */
-  private val comparableAnnotations by lazy { annotations.joinToString() }
+  private val comparableAnnotations = annotations.joinToString()
 
   /** Fully qualified name using `.` as a separator, like `kotlin.collections.Map.Entry`. */
   public val canonicalName: String = if (names[0].isEmpty())

--- a/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
+++ b/kotlinpoet/src/main/java/com/squareup/kotlinpoet/ClassName.kt
@@ -74,6 +74,12 @@ public class ClassName internal constructor(
   /** From top to bottom. This will be `["java.util", "Map", "Entry"]` for `Map.Entry`. */
   private val names = names.toImmutableList()
 
+  /** String representation of the names used when comparing to other ClassName */
+  private val comparableNames = names.joinToString()
+
+  /** String representation of the annotations used when comparing to other ClassName */
+  private val comparableAnnotations by lazy { annotations.joinToString() }
+
   /** Fully qualified name using `.` as a separator, like `kotlin.collections.Map.Entry`. */
   public val canonicalName: String = if (names[0].isEmpty())
     names.subList(1, names.size).joinToString(".") else
@@ -175,8 +181,9 @@ public class ClassName internal constructor(
    * com.example.Robot.Motor
    * com.example.RoboticVacuum
    * ```
+   * Comparison is consistent with equals()
    */
-  override fun compareTo(other: ClassName): Int = canonicalName.compareTo(other.canonicalName)
+  override fun compareTo(other: ClassName): Int = COMPARATOR.compare(this, other)
 
   override fun emit(out: CodeWriter) =
     out.emit(out.lookupName(this).escapeSegmentsIfNecessary())
@@ -230,6 +237,10 @@ public class ClassName internal constructor(
       require(names.size >= 2) { "couldn't make a guess for $classNameString" }
       return ClassName(names)
     }
+
+    private val COMPARATOR: Comparator<ClassName> = compareBy<ClassName> { it.comparableNames }
+      .thenBy { it.isNullable }
+      .thenBy { it.comparableAnnotations }
   }
 }
 

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -248,4 +248,112 @@ class ClassNameTest {
     assertThat(foo).isEqualTo(taggedFoo)
     assertThat(foo.hashCode()).isEqualTo(taggedFoo.hashCode())
   }
+
+  @Test fun compareTo() {
+    val robot = ClassName("com.example", "Robot")
+    val robotMotor = ClassName("com.example", "Robot", "Motor")
+    val roboticVacuum = ClassName("com.example", "RoboticVacuum")
+
+    val list = listOf(robot, robotMotor, roboticVacuum)
+
+    assertThat(list.sorted()).isEqualTo(listOf(robot, robotMotor, roboticVacuum))
+  }
+
+  @Test fun compareToConsistentWithEquals() {
+    val foo1 = ClassName(names = listOf("com.example", "Foo"))
+    val foo2 = ClassName(names = listOf("com.example", "Foo"))
+    assertThat(foo1.compareTo(foo2)).isEqualTo(0)
+  }
+
+  @Test fun compareToDifferentiatesPackagesFromSimpleNames() {
+    val outerFooNestedBar = ClassName("com.example", "Foo", "Bar")
+    val packageFooClassBar = ClassName("com.example.Foo", "Bar")
+    val outerFooNestedBaz = ClassName("com.example", "Foo", "Baz")
+    val packageFooClassBaz = ClassName("com.example.Foo", "Baz")
+    val outerGooNestedBar = ClassName("com.example", "Goo", "Bar")
+    val packageGooClassBar = ClassName("com.example.Goo", "Bar")
+
+    val list = listOf(
+      outerFooNestedBar, packageFooClassBar, outerFooNestedBaz, packageFooClassBaz, outerGooNestedBar,
+      packageGooClassBar,
+    )
+
+    assertThat(list.sorted()).isEqualTo(
+      listOf(
+        outerFooNestedBar,
+        outerFooNestedBaz,
+        outerGooNestedBar,
+        packageFooClassBar,
+        packageFooClassBaz,
+        packageGooClassBar,
+      ),
+    )
+  }
+
+  @Test fun compareToDifferentiatesNullabilityAndAnnotations() {
+    val plain = ClassName(
+      listOf("com.example", "Foo")
+    )
+    val nullable = ClassName(
+      listOf("com.example", "Foo"),
+      nullable = true,
+    )
+    val annotated = ClassName(
+      listOf("com.example", "Foo"),
+      nullable = true,
+      annotations = listOf(
+        AnnotationSpec.Builder(Suppress::class.asClassName()).build(),
+      ),
+    )
+
+    val list = listOf(plain, nullable, annotated)
+
+    assertThat(list.sorted()).isEqualTo(
+      listOf(plain, nullable, annotated),
+    )
+  }
+
+  @Test fun compareToDifferentiatesByAnnotation() {
+    val noAnnotations = ClassName(listOf("com.example", "Foo"))
+
+    val oneAnnotation = ClassName(
+      listOf("com.example", "Foo"),
+      annotations = listOf(AnnotationSpec.Builder(Suppress::class.asClassName()).build()),
+    )
+    val twoAnnotations = ClassName(
+      listOf("com.example", "Foo"),
+      annotations = listOf(
+        AnnotationSpec.Builder(Suppress::class.asClassName()).build(),
+        AnnotationSpec.Builder(Test::class.asClassName()).build(),
+      ),
+    )
+    val secondAnnotationOnly = ClassName(
+      listOf("com.example", "Foo"),
+      annotations = listOf(
+        AnnotationSpec.Builder(Test::class.asClassName()).build(),
+      ),
+    )
+
+    val list = listOf(noAnnotations, oneAnnotation, twoAnnotations, secondAnnotationOnly)
+
+    assertThat(list.sorted()).isEqualTo(
+      listOf(noAnnotations, oneAnnotation, twoAnnotations, secondAnnotationOnly),
+    )
+  }
+
+  @Test fun compareToDoesNotDifferentiateByTag() {
+    val noTags = ClassName(listOf("com.example", "Foo"))
+
+    val oneTag = ClassName(
+      listOf("com.example", "Foo"),
+      tags = mapOf(String::class to "test"),
+    )
+    val twoTags = ClassName(
+      listOf("com.example", "Foo"),
+      tags = mapOf(String::class to "test", UInt::class to 1),
+    )
+
+    assertThat(noTags.compareTo(oneTag)).isEqualTo(0)
+    assertThat(oneTag.compareTo(twoTags)).isEqualTo(0)
+  }
 }

--- a/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
+++ b/kotlinpoet/src/test/java/com/squareup/kotlinpoet/ClassNameTest.kt
@@ -266,23 +266,27 @@ class ClassNameTest {
   }
 
   @Test fun compareToDifferentiatesPackagesFromSimpleNames() {
-    val outerFooNestedBar = ClassName("com.example", "Foo", "Bar")
+    val parentFooNestedBar = ClassName("com.example", "Foo", "Bar")
     val packageFooClassBar = ClassName("com.example.Foo", "Bar")
-    val outerFooNestedBaz = ClassName("com.example", "Foo", "Baz")
+    val parentFooNestedBaz = ClassName("com.example", "Foo", "Baz")
     val packageFooClassBaz = ClassName("com.example.Foo", "Baz")
-    val outerGooNestedBar = ClassName("com.example", "Goo", "Bar")
+    val parentGooNestedBar = ClassName("com.example", "Goo", "Bar")
     val packageGooClassBar = ClassName("com.example.Goo", "Bar")
 
     val list = listOf(
-      outerFooNestedBar, packageFooClassBar, outerFooNestedBaz, packageFooClassBaz, outerGooNestedBar,
+      parentFooNestedBar,
+      packageFooClassBar,
+      parentFooNestedBaz,
+      packageFooClassBaz,
+      parentGooNestedBar,
       packageGooClassBar,
     )
 
     assertThat(list.sorted()).isEqualTo(
       listOf(
-        outerFooNestedBar,
-        outerFooNestedBaz,
-        outerGooNestedBar,
+        parentFooNestedBar,
+        parentFooNestedBaz,
+        parentGooNestedBar,
         packageFooClassBar,
         packageFooClassBaz,
         packageGooClassBar,
@@ -350,7 +354,7 @@ class ClassNameTest {
     )
     val twoTags = ClassName(
       listOf("com.example", "Foo"),
-      tags = mapOf(String::class to "test", UInt::class to 1),
+      tags = mapOf(String::class to "test", Int::class to 1),
     )
 
     assertThat(noTags.compareTo(oneTag)).isEqualTo(0)


### PR DESCRIPTION
Stacks on #1477

To make compareTo consistent with equals we have to ensure:

> e1.compareTo(e2) == 0 has the same boolean value as e1.equals(e2) for every e1 and e2 of class C. 

https://blog.joda.org/2012/11/pitfalls-of-consistent-with-equals.html

In other words, we cannot get a `compareTo == 0` result for two unequal ClassName.

For ClassName, we are comparing by name parts, by nullability, then by annotations. 

Comparing by name parts and nullability are safe because equality of ClassName is defined by equality of name (in ClassName.kt) and nullability (through the super TypeName).

In general, comparing by using `joinToString()` on some list property included in equals checks is not safe when you have two elements in the list x and y where `listOf(x, y).joinToString()` is the same as `listOf(x + y).joinToString()`. 

See this Kotlin Playground for an example:
https://pl.kotl.in/oCxOv0Sjh

In this particular case, it is safe because we can never have a single AnnotationSpec in a list that gives the same `joinToString()` as two separate AnnotationSpec in a list and because equality of AnnotationSpec is equality of string representation.